### PR TITLE
added the possibility of passing around an object with arbitrary data

### DIFF
--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -64,6 +64,36 @@ class RootTestParser(parser.RootParser):
     start = StartParser
 
 
+class RootTestParserWithExtra(parser.RootParser):
+    class start(parser.Parser):
+        class elements(parser.Parser):
+            class element(parser.Parser):
+                class Yangify(parser.ParserData):
+                    def extract_elements(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
+                        assert self.extra == {"os_version": "test"}
+                        for k, v in test_data.items():
+                            yield k, v
+
+                def name(self) -> str:
+                    assert self.yy.extra == {"os_version": "test"}
+                    return self.yy.key
+
+                class config(parser.Parser):
+                    class Yangify(parser.ParserData):
+                        def pre_process(self) -> None:
+                            assert self.extra == {"os_version": "test"}
+                            self.native = self.native["config"]
+
+                    def description(self) -> str:
+                        assert self.yy.extra == {"os_version": "test"}
+                        return cast(str, self.yy.native["description"])
+
+                class state(parser.Parser):
+                    def description(self) -> str:
+                        assert self.yy.extra == {"os_version": "test"}
+                        return cast(str, self.yy.native["state"]["description"])
+
+
 class Test:
     def test_parse_all(self) -> None:
         parser = RootTestParser(dm, test_data, config=True, state=True)
@@ -121,6 +151,58 @@ class Test:
 
     def test_parse_state(self) -> None:
         parser = RootTestParser(dm, test_data, config=False, state=True)
+        parsed_obj = parser.process()
+        assert parsed_obj.raw_value() == {
+            "yangify-tests:start": {
+                "elements": {
+                    "element": [
+                        {
+                            "name": "element1",
+                            "state": {
+                                "description": "this is element1.state.description"
+                            },
+                        },
+                        {
+                            "name": "element2",
+                            "state": {
+                                "description": "this is element2.state.description"
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+    def test_parse_config_with_extra(self) -> None:
+        parser = RootTestParserWithExtra(
+            dm, test_data, config=True, state=False, extra={"os_version": "test"}
+        )
+        parsed_obj = parser.process()
+        assert parsed_obj.raw_value() == {
+            "yangify-tests:start": {
+                "elements": {
+                    "element": [
+                        {
+                            "name": "element1",
+                            "config": {
+                                "description": "this is element1.config.description"
+                            },
+                        },
+                        {
+                            "name": "element2",
+                            "config": {
+                                "description": "this is element2.config.description"
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+    def test_parse_state_with_extra(self) -> None:
+        parser = RootTestParserWithExtra(
+            dm, test_data, config=False, state=True, extra={"os_version": "test"}
+        )
         parsed_obj = parser.process()
         assert parsed_obj.raw_value() == {
             "yangify-tests:start": {

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -23,6 +23,41 @@ test_data = {
     },
 }
 
+test_expected_config = {
+    "yangify-tests:start": {
+        "elements": {
+            "element": [
+                {
+                    "name": "element1",
+                    "config": {"description": "this is element1.config.description"},
+                },
+                {
+                    "name": "element2",
+                    "config": {"description": "this is element2.config.description"},
+                },
+            ]
+        }
+    }
+}
+
+
+test_expected_state = {
+    "yangify-tests:start": {
+        "elements": {
+            "element": [
+                {
+                    "name": "element1",
+                    "state": {"description": "this is element1.state.description"},
+                },
+                {
+                    "name": "element2",
+                    "state": {"description": "this is element2.state.description"},
+                },
+            ]
+        }
+    }
+}
+
 
 class ConfigParser(parser.Parser):
     class Yangify(parser.ParserData):
@@ -65,6 +100,12 @@ class RootTestParser(parser.RootParser):
 
 
 class RootTestParserWithExtra(parser.RootParser):
+    """
+    This is just a sample parser similar to RootTestParser
+    but that asserts at different points that `extra`
+    is set to a predetermined value
+    """
+
     class start(parser.Parser):
         class elements(parser.Parser):
             class element(parser.Parser):
@@ -128,99 +169,23 @@ class Test:
     def test_parse_config(self) -> None:
         parser = RootTestParser(dm, test_data, config=True, state=False)
         parsed_obj = parser.process()
-        assert parsed_obj.raw_value() == {
-            "yangify-tests:start": {
-                "elements": {
-                    "element": [
-                        {
-                            "name": "element1",
-                            "config": {
-                                "description": "this is element1.config.description"
-                            },
-                        },
-                        {
-                            "name": "element2",
-                            "config": {
-                                "description": "this is element2.config.description"
-                            },
-                        },
-                    ]
-                }
-            }
-        }
+        assert parsed_obj.raw_value() == test_expected_config
 
     def test_parse_state(self) -> None:
         parser = RootTestParser(dm, test_data, config=False, state=True)
         parsed_obj = parser.process()
-        assert parsed_obj.raw_value() == {
-            "yangify-tests:start": {
-                "elements": {
-                    "element": [
-                        {
-                            "name": "element1",
-                            "state": {
-                                "description": "this is element1.state.description"
-                            },
-                        },
-                        {
-                            "name": "element2",
-                            "state": {
-                                "description": "this is element2.state.description"
-                            },
-                        },
-                    ]
-                }
-            }
-        }
+        assert parsed_obj.raw_value() == test_expected_state
 
     def test_parse_config_with_extra(self) -> None:
         parser = RootTestParserWithExtra(
             dm, test_data, config=True, state=False, extra={"os_version": "test"}
         )
         parsed_obj = parser.process()
-        assert parsed_obj.raw_value() == {
-            "yangify-tests:start": {
-                "elements": {
-                    "element": [
-                        {
-                            "name": "element1",
-                            "config": {
-                                "description": "this is element1.config.description"
-                            },
-                        },
-                        {
-                            "name": "element2",
-                            "config": {
-                                "description": "this is element2.config.description"
-                            },
-                        },
-                    ]
-                }
-            }
-        }
+        assert parsed_obj.raw_value() == test_expected_config
 
     def test_parse_state_with_extra(self) -> None:
         parser = RootTestParserWithExtra(
             dm, test_data, config=False, state=True, extra={"os_version": "test"}
         )
         parsed_obj = parser.process()
-        assert parsed_obj.raw_value() == {
-            "yangify-tests:start": {
-                "elements": {
-                    "element": [
-                        {
-                            "name": "element1",
-                            "state": {
-                                "description": "this is element1.state.description"
-                            },
-                        },
-                        {
-                            "name": "element2",
-                            "state": {
-                                "description": "this is element2.state.description"
-                            },
-                        },
-                    ]
-                }
-            }
-        }
+        assert parsed_obj.raw_value() == test_expected_state

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -29,8 +29,25 @@ test_data = {
     }
 }
 
+test_expected = {
+    "element1": {
+        "description": "this is element1.config.description",
+        "name": "element1",
+    },
+    "element2": {
+        "description": "this is element2.config.description",
+        "name": "element2",
+    },
+}
+
 
 class RootTestTranslatorWithExtra(translator.RootTranslator):
+    """
+    This is just a sample translator
+    but that asserts at different points that `extra`
+    is set to a predetermined value
+    """
+
     class Yangify(translator.TranslatorData):
         def init(self) -> None:
             self.root_result = {}
@@ -68,13 +85,4 @@ class Test:
             dm, candidate=test_data, extra={"os_version": "test"}
         )
         translated_obj = translater.process()
-        assert translated_obj == {
-            "element1": {
-                "description": "this is element1.config.description",
-                "name": "element1",
-            },
-            "element2": {
-                "description": "this is element2.config.description",
-                "name": "element2",
-            },
-        }
+        assert translated_obj == test_expected

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -1,0 +1,80 @@
+import pathlib
+from typing import Optional
+
+from yangify import translator
+
+from yangson.datamodel import DataModel
+
+
+BASE = pathlib.Path(__file__).parent
+dm = DataModel.from_file(
+    f"{BASE}/yang/simple/yang-library-data.json", [f"{BASE}/yang/simple/"]
+)
+
+
+test_data = {
+    "yangify-tests:start": {
+        "elements": {
+            "element": [
+                {
+                    "name": "element1",
+                    "config": {"description": "this is element1.config.description"},
+                },
+                {
+                    "name": "element2",
+                    "config": {"description": "this is element2.config.description"},
+                },
+            ]
+        }
+    }
+}
+
+
+class RootTestTranslatorWithExtra(translator.RootTranslator):
+    class Yangify(translator.TranslatorData):
+        def init(self) -> None:
+            self.root_result = {}
+            self.result = self.root_result
+
+    class start(translator.Translator):
+        class elements(translator.Translator):
+            class element(translator.Translator):
+                class Yangify(translator.TranslatorData):
+                    def pre_process(self) -> None:
+                        assert self.extra == {"os_version": "test"}
+                        self.root_result[self.key] = {}
+                        self.result = self.root_result[self.key]
+
+                    def pre_process_list(self) -> None:
+                        assert self.extra == {"os_version": "test"}
+
+                def name(self, value: Optional[bool]) -> None:
+                    assert self.yy.extra == {"os_version": "test"}
+                    self.yy.result["name"] = value
+
+                class config(translator.Translator):
+                    class Yangify(translator.TranslatorData):
+                        def pre_process(self) -> None:
+                            assert self.extra == {"os_version": "test"}
+
+                    def description(self, value: Optional[bool]) -> None:
+                        assert self.yy.extra == {"os_version": "test"}
+                        self.yy.result["description"] = value
+
+
+class Test:
+    def test_translate_config_with_extra(self) -> None:
+        translater = RootTestTranslatorWithExtra(
+            dm, candidate=test_data, extra={"os_version": "test"}
+        )
+        translated_obj = translater.process()
+        assert translated_obj == {
+            "element1": {
+                "description": "this is element1.config.description",
+                "name": "element1",
+            },
+            "element2": {
+                "description": "this is element2.config.description",
+                "name": "element2",
+            },
+        }

--- a/yangify/parser/__init__.py
+++ b/yangify/parser/__init__.py
@@ -60,6 +60,10 @@ class ParserData:
                     "openconfig-interfaces:interfaces/interface": "FastEthernet1",
                     "openconfig-interfaces:interfaces/interface/subinterfaces/subinterface": 1,
                 }
+
+        extra (`Dict[str, Any]`): Arbitrary data that can be defined by the user when instantiating
+            the root of the object. Useful to share arbitrary information throughout the entire
+            lifecycle of the parser
     """
 
     path = ""
@@ -71,11 +75,13 @@ class ParserData:
         native: Any,
         root_native: Any,
         keys: Dict[str, str],
+        extra: Dict[str, Any],
     ) -> None:
         self.schema = schema
         self.native = native
         self.root_native = root_native
         self.keys = keys
+        self.extra = extra
 
     @property
     def key(self) -> str:
@@ -159,9 +165,10 @@ class Parser:
         native: Any,
         root_native: Any,
         keys: Dict[str, str],
+        extra: Dict[str, Any],
     ) -> None:
         self.model_filter = model_filter
-        self.yy: ParserData = self.Yangify(schema, native, root_native, keys)
+        self.yy: ParserData = self.Yangify(schema, native, root_native, keys, extra)
 
     def __str__(self) -> str:
         return str(self.yy.schema.data_path())
@@ -181,6 +188,7 @@ class Parser:
                 self.yy.native,
                 self.yy.root_native,
                 self.yy.keys,
+                self.yy.extra,
             ),
         )
 
@@ -287,6 +295,10 @@ class RootParser(Parser):
 
         state: Parse state leaves
 
+        extra (`Dict[str, Any]`): Arbitrary data that can be defined by the user when instantiating
+            the root of the object. Useful to share arbitrary information throughout the entire
+            lifecycle of the parser
+
     Examples:
 
         Parsing both ``openconfig-interfaces`` and ``openconfig-vlan`` models::
@@ -322,6 +334,7 @@ class RootParser(Parser):
         state: bool = False,
         include: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
+        extra: Dict[str, Any] = None,
     ) -> None:
         if not config and not state:
             raise ValueError("either config or state must be true")
@@ -330,7 +343,7 @@ class RootParser(Parser):
         self.state = state
         include = include if include is not None else ["/"]
         model_filter = ModelFilter(include=include, exclude=exclude or [])
-        super().__init__(self.dm.schema, model_filter, native, native, {})
+        super().__init__(self.dm.schema, model_filter, native, native, {}, extra or {})
 
     def __str__(self) -> str:
         return self.__class__.__qualname__

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -504,16 +504,16 @@ class RootTranslator(Translator):
             o = None
 
         super().__init__(
-            None,
-            None,
-            instance.InstanceRoute(),
-            dm,
-            dm.schema,
-            {},
-            n,
-            o,
-            replace,
-            extra or {},
+            result=None,
+            root_result=None,
+            path=instance.InstanceRoute(),
+            dm=dm,
+            schema=dm.schema,
+            keys={},
+            candidate=n,
+            running=o,
+            replace=replace,
+            extra=extra or {},
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
When instantiating a parser/translator you can pass an arbitrary dict via the parameter `extra`:

https://github.com/networktocode/yangify/pull/12/files#diff-a6e2a0866ba4b2ee96b797b1ed04e13bR178

That dictionary will be available throughout the entire lifecycle of the object via `self.yy.extra`:

https://github.com/networktocode/yangify/pull/12/files#diff-a6e2a0866ba4b2ee96b797b1ed04e13bR73
https://github.com/networktocode/yangify/pull/12/files#diff-a6e2a0866ba4b2ee96b797b1ed04e13bR78