### PR TITLE
Fix leaf-list processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ override PYTHON=3.6
 endif
 
 NAME=yangify
-DOCKER=docker run -v $(PWD):/yangify yangify-${PYTHON}:latest
+DOCKER=docker run -it -v $(PWD):/yangify yangify-${PYTHON}:latest
 DEV_JUPYTER=docker run -p 8888:8888 -v $(PWD):/yangify ${NAME}-${PYTHON}:latest
 DEV_ME=docker run -it -v $(PWD):/yangify ${NAME}-${PYTHON}:latest /bin/bash
 

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -168,7 +168,7 @@ class RootTestTranslatorPreProcessLeafList(translator.RootTranslator):
 
                         def post_process_leaf_list(self) -> None:
                             self.root_result["test"] = "test"
-                            assert self.result.get("members") is None
+                            assert self.result.get("members") == []
 
                     def description(self, value: Optional[bool]) -> None:
                         self.yy.result["description"] = value

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -168,6 +168,7 @@ class RootTestTranslatorPreProcessLeafList(translator.RootTranslator):
 
                         def post_process_leaf_list(self) -> None:
                             self.root_result["test"] = "test"
+                            assert self.result.get("members") is None
 
                     def description(self, value: Optional[bool]) -> None:
                         self.yy.result["description"] = value

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -21,14 +21,14 @@ test_data = {
                     "name": "element1",
                     "config": {
                         "description": "this is element1.config.description",
-                        "members": ["the", "first", "list"]
+                        "members": ["the", "first", "list"],
                     },
                 },
                 {
                     "name": "element2",
                     "config": {
                         "description": "this is element2.config.description",
-                        "members": ["the", "second", "list"]
+                        "members": ["the", "second", "list"],
                     },
                 },
             ]
@@ -57,14 +57,14 @@ test_leaf_list_candidate = {
                     "name": "element1",
                     "config": {
                         "description": "this is element1.config.description",
-                        "members": ["one", "two"]
+                        "members": ["one", "two"],
                     },
                 },
                 {
                     "name": "element2",
                     "config": {
                         "description": "this is element2.config.description",
-                        "members": ["one", "two"]
+                        "members": ["one", "two"],
                     },
                 },
             ]
@@ -80,20 +80,21 @@ test_leaf_list_running = {
                     "name": "element1",
                     "config": {
                         "description": "this is element1.config.description",
-                        "members": ["one", "two", "three"]
+                        "members": ["one", "two", "three"],
                     },
                 },
                 {
                     "name": "element2",
                     "config": {
                         "description": "this is element2.config.description",
-                        "members": ["one", "two", "three"]
+                        "members": ["one", "two", "three"],
                     },
                 },
             ]
         }
     }
 }
+
 
 class RootTestTranslatorWithExtra(translator.RootTranslator):
     """
@@ -182,7 +183,9 @@ class Test:
         )
         translated_obj = translator.process()
         # Nested dicts require key order to match in comparisons
-        assert json.dumps(translated_obj, sort_keys=True) == json.dumps(test_expected, sort_keys=True)
+        assert json.dumps(translated_obj, sort_keys=True) == json.dumps(
+            test_expected, sort_keys=True
+        )
 
     def test_translate_config_leaf_list(self) -> None:
         translator = RootTestTranslatorPreProcessLeafList(

--- a/tests/unit/yang/simple/yangify-tests.yang
+++ b/tests/unit/yang/simple/yangify-tests.yang
@@ -18,6 +18,9 @@ module yangify-tests {
                     leaf description {
                         type string;
                     }
+                    leaf-list members {
+                        type string;
+                    }
                 }
                 container state {
                     config false;

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -403,12 +403,14 @@ class Translator:
             # TODO: if we decide to have a "use defaults" parameters
             # this will have to be set to `leaf.default
             candidate = None
-        else:
+        elif not self.yy.replace:
             # only process child if there are elements to add
             elements = running.value if running else []
             candidate = [
                 i for i in self._get_inst_value(leaf_path) if i not in elements
             ] or []
+        else:
+            candidate = self._get_inst_value(leaf_path)
         c(candidate)
         self.yy.post_process_leaf_list()
 

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -404,7 +404,11 @@ class Translator:
             # this will have to be set to `leaf.default
             candidate = None
         else:
-            candidate = list(set(self._get_inst_value(leaf_path)) - set(running.value)) or None
+            # only process child if there are elements to add
+            elements = running.value if running else []
+            candidate = [
+                i for i in self._get_inst_value(leaf_path) if i not in elements
+            ] or []
         c(candidate)
         self.yy.post_process_leaf_list()
 

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -476,7 +476,7 @@ class Translator:
         self.yy.values_to_remove = []
         this = running.raw_value() if running else []
         other = candidate.raw_value() if candidate else []
-        self.yy.values_to_remove = list(set(this) - set(other))
+        self.yy.values_to_remove = [i for i in this if i not in other]
 
     def _extract_key(self, element: instance.ArrayEntry) -> str:
         return cast(str, element.value[element.schema_node.keys[0][0]])

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -404,7 +404,7 @@ class Translator:
             # this will have to be set to `leaf.default
             candidate = None
         else:
-            candidate = self._get_inst_value(leaf_path)
+            candidate = list(set(self._get_inst_value(leaf_path)) - set(running.value)) or None
         c(candidate)
         self.yy.post_process_leaf_list()
 

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -473,6 +473,20 @@ class Translator:
     def _fill_to_remove_values(
         self, candidate: Optional[instance.ObjectValue], running: instance.ObjectValue
     ) -> None:
+        """
+        This method returns the set difference of candidate - running.
+
+        The method uses a list comprehension in order to preserve the list order
+        as it is passed in from the caller.  The difference is set on the `values_to_remove`
+        class attribute.
+
+        Args:
+            candidate: list of values in the candidate leaf-list
+            running: list of values in the running leaf-list
+
+        Returns:
+            None
+        """
         self.yy.values_to_remove = []
         this = running.raw_value() if running else []
         other = candidate.raw_value() if candidate else []

--- a/yangify/translator/__init__.py
+++ b/yangify/translator/__init__.py
@@ -78,6 +78,11 @@ class TranslatorData:
             either a merge or replace operation, this List will be populated with the elements
             that need to be removed.
 
+        values_to_remove (`List[Any]`): When processing YANG leaf-lists and performing
+            either a merge or replace operation, this List will be populated with the elements
+            that need to be removed.  The contents of the list are cooked values mapped from
+            types in yangson.instance.ObjectValue.
+
         extra (`Dict[str, Any]`): Arbitrary data that can be defined by the user when instantiating
             the root of the object. Useful to share arbitrary information throughout the entire
             lifecycle of the translator
@@ -144,7 +149,7 @@ class TranslatorData:
 
     def pre_process_leaf_list(self) -> None:
         """
-        This is called before processing a list.
+        This is called before processing a leaf-list.
         """
         pass
 
@@ -156,7 +161,7 @@ class TranslatorData:
 
     def post_process_leaf_list(self) -> None:
         """
-        This is called after processing a list.
+        This is called after processing a leaf-list.
         """
         pass
 
@@ -357,8 +362,19 @@ class Translator:
             candidate = self._get_inst_value(leaf_path)
         c(candidate)
 
-    def _process_leaf_list(self, leaf: schemanode.DataNode) -> None:
-        leaf_path = self._append_node_to_path(self.yy.path, leaf)
+    def _process_leaf_list(self, leaf_list: schemanode.DataNode) -> None:
+        """Process yangson.schemanode.LeafLiftNode data.
+
+        Process leaf-list nodes and populate self.yy.values_to_remove.
+
+        Args:
+            leaf_list: yangson.schemanode.LeafListNode
+
+        Returns:
+            None
+
+        """
+        leaf_path = self._append_node_to_path(self.yy.path, leaf_list)
         logger.debug("%s: is a leaf list", leaf_path)
         if not self._obj_forward_progress_leaf(leaf_path):
             logger.debug("%s: no need to progress", leaf_path)
@@ -377,7 +393,7 @@ class Translator:
         self._fill_to_remove_values(elements, running)
         self.yy.pre_process_leaf_list()
 
-        child_name = leaf.name.replace("-", "_")
+        child_name = leaf_list.name.replace("-", "_")
         c = getattr(self, f"{child_name}", None)
         if not c:
             logger.info("%s: (set) not implemented", leaf_path)


### PR DESCRIPTION
This addresses #19 

This doesn't process leaf-lists and fails on merges:
https://github.com/networktocode/yangify/blob/develop/yangify/translator/__init__.py#L378
```python
            elif isinstance(child, (schemanode.LeafNode, schemanode.LeafListNode)):
                self._process_leaf(child)
```

The new `self._process_leaf_list` peeks into the values of running/candidate and diff's the set.
```python
  class DnsConfig(Translator):
      class Yangify(TranslatorData):
          path = "/openconfig-system:system/dns/config"

+         def pre_process_leaf_list(self) -> None:
+             if self.values_to_remove and not self.replace:
+                 for value in self.values_to_remove:
+                     etree.SubElement(self.result, "domain-search", delete="delete").text = value
+
      def search(self, value: List[str]) -> None:
          for v in value:
              etree.SubElement(self.yy.result, "domain-search").text = v
```

`pre_process[list]` is called **before** yangify descends into member attributes, so I call `self.yy.pre_process_leaf_list` from the leaf-list processor.
There is also a new `post_process_leaf_list` in the event it is needed
for functionality.