### PR TITLE
Changed deploy back to native poetry and non make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: minimal
 dist: xenial
 script:
 - make tests
+before_deploy:
+- curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+- $HOME/.poetry/bin/poetry config http-basic.pypi $PYPI_USER $PYPI_PASSWORD
+- $HOME/.poetry/bin/poetry build
 deploy:
   provider: script
-  script: make publish
+  script: poetry publish
   on:
     tags: true
 env:

--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,6 @@ docs:
 install:
 	poetry install
 
-.PHONY: publish
-publish:
-	${DOCKER} \
-		poetry publish --build --username=$(PYPI_USER) --password="$(PYPI_PASSWORD)"
-
 .PHONY: _jupyter
 _jupyter:
 	poetry install
@@ -120,7 +115,6 @@ _jupyter_save:
 jupyter_save:
 	${DOCKER} \
 		make _jupyter_save
-
 
 .PHONY: dev_jupyter
 dev_jupyter:


### PR DESCRIPTION
This is still working on the post deploy. It failed due to make commands using `()` instead of `{}` for env variables. Using Make does end up showing the credentials as well so went back to original way with native poetry. Along with updating the global envs, I believe this should work, but will have to merge this after tests pass and then tag another release (`v0.1.2`)