### PR TITLE
PyPi upload works when specifying un/pw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,14 @@ services:
 - docker
 python: 3.6
 script:
-- pip install poetry
-- python -V
-- python3 -V
 - make tests
 before_deploy:
 - pip install poetry
-- python -V
-- python3 -V
-- poetry config http-basic.pypi $PYPI_USER $PYPI_PASSWORD
 - poetry build
 deploy:
   provider: script
-  script: poetry publish
+  script: poetry publish --username "$PYPI_USER" --password "$PYPI_PASSWORD"
+  skip_cleanup: true
   on:
     tags: true
 env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yangify"
-version = "0.1.1"
+version = "0.1.2"
 description = "Library to help parsing/translating YANG models from/to native text/structures"
 readme = "README.md"
 authors = ["David Barroso <dbarrosop@dravetech.com>"]


### PR DESCRIPTION
Tested outside of deploy scenario and within Travis-CI env and it appears to work when adding `--username` and `--password` to `poetry publish` command.