### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM python:${PYTHON}-stretch
 
 RUN apt-get update && apt-get install -y pandoc
 
-RUN pip install poetry==1.0.0 && poetry config virtualenvs.create false && pip install -U pip
+RUN pip install --no-cache-dir poetry==1.0.0 && poetry config virtualenvs.create false && pip install --no-cache-dir -U pip
 
 ADD poetry.lock /tmp
 ADD pyproject.toml /tmp
 RUN cd /tmp && poetry install
 
 ADD docs/requirements.txt /tmp/requirements-docs.txt
-RUN pip install -r /tmp/requirements-docs.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-docs.txt
 
 ADD . /yangify
 


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>